### PR TITLE
feat: update splunk/addonfactory-ucc-generator-action to v2

### DIFF
--- a/.github/workflows/reusable-publish-manual.yaml
+++ b/.github/workflows/reusable-publish-manual.yaml
@@ -83,7 +83,7 @@ jobs:
           PrNumber: ${{ github.event.number }}
       - name: Build Package
         id: uccgen
-        uses: splunk/addonfactory-ucc-generator-action@v1
+        uses: splunk/addonfactory-ucc-generator-action@v2
         with:
           version: ${{ steps.BuildVersion.outputs.VERSION }}
       - name: Slim Package


### PR DESCRIPTION
This PR updates splunk/addonfactory-ucc-generator-action to v2 so `poetry` v1.5.1 will be used.